### PR TITLE
update to Oxygen and Tycho 1.0; remove...

### DIFF
--- a/org.eclipse.equinox.p2.example.p2diff.packaging/p2diff.product
+++ b/org.eclipse.equinox.p2.example.p2diff.packaging/p2diff.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="p2diff" uid="org.eclipse.equinox.p2.example.p2diff.product" application="org.eclipse.equinox.p2.example.p2diff.application" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="true">
+<product name="p2diff" uid="org.eclipse.equinox.p2.example.p2diff.product" application="org.eclipse.equinox.p2.example.p2diff.application" version="1.0.1.qualifier" useFeatures="false" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>

--- a/org.eclipse.equinox.p2.example.p2diff.packaging/pom.xml
+++ b/org.eclipse.equinox.p2.example.p2diff.packaging/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2.example</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>../org.eclipse.equinox.p2.example.p2diff.releng/parent</relativePath>
   </parent>
 
@@ -66,13 +66,6 @@
         <version>${tycho-version}</version>
         <configuration>
           <includeAllDependencies>true</includeAllDependencies>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-p2-director-plugin</artifactId>
-        <version>${tycho-version}</version>
-        <configuration>
           <products>
             <product>
               <id>org.eclipse.equinox.p2.example.p2diff.product</id>

--- a/org.eclipse.equinox.p2.example.p2diff.releng/parent/pom.xml
+++ b/org.eclipse.equinox.p2.example.p2diff.releng/parent/pom.xml
@@ -6,18 +6,18 @@
   <name>Parent POM</name>
   <artifactId>parent</artifactId>
   <groupId>org.eclipse.equinox.p2.example</groupId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
-    <tycho-version>0.20.0</tycho-version>
+    <tycho-version>1.0.0</tycho-version>
   </properties>
 
   <repositories>
     <repository>
-      <id>luna-R</id>
+      <id>oxygen</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/luna/201406250900</url>
+      <url>http://download.eclipse.org/releases/oxygen</url>
     </repository>
   </repositories>
   <build>
@@ -49,11 +49,6 @@
               <os>linux</os>
               <ws>gtk</ws>
               <arch>x86_64</arch>
-            </environment>
-            <environment>
-              <os>macosx</os>
-              <ws>cocoa</ws>
-              <arch>x86</arch>
             </environment>
             <environment>
               <os>win32</os>

--- a/org.eclipse.equinox.p2.example.p2diff.releng/pom.xml
+++ b/org.eclipse.equinox.p2.example.p2diff.releng/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2.example</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>../org.eclipse.equinox.p2.example.p2diff.releng/parent</relativePath>
   </parent>
 

--- a/org.eclipse.equinox.p2.example.p2diff.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.equinox.p2.example.p2diff.tests/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: org.eclipse.equinox.p2.example.p2diff.tests
-Bundle-Version: 1.0.0.qualifier
-Fragment-Host: org.eclipse.equinox.p2.example.p2diff;bundle-version="1.0.0"
+Bundle-Version: 1.0.1.qualifier
+Fragment-Host: org.eclipse.equinox.p2.example.p2diff;bundle-version="1.0.1"
 Require-Bundle: org.eclipse.core.runtime,
  org.junit;bundle-version="4.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/org.eclipse.equinox.p2.example.p2diff.tests/pom.xml
+++ b/org.eclipse.equinox.p2.example.p2diff.tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2.example</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>../org.eclipse.equinox.p2.example.p2diff.releng/parent</relativePath>
   </parent>
 

--- a/org.eclipse.equinox.p2.example.p2diff/META-INF/MANIFEST.MF
+++ b/org.eclipse.equinox.p2.example.p2diff/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: P2diff
 Bundle-SymbolicName: org.eclipse.equinox.p2.example.p2diff; singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Activator: org.eclipse.equinox.p2.example.p2diff.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.p2.metadata;bundle-version="2.0.0",

--- a/org.eclipse.equinox.p2.example.p2diff/pom.xml
+++ b/org.eclipse.equinox.p2.example.p2diff/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.equinox.p2.example</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>../org.eclipse.equinox.p2.example.p2diff.releng/parent</relativePath>
   </parent>
 


### PR DESCRIPTION
update to Oxygen and Tycho 1.0; remove cocoa-x86 (doesn't exist anymore); fix tycho p2-director plugin warning

Signed-off-by: nickboldt <nboldt@redhat.com>